### PR TITLE
Set the default databank driver to disk

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -52,6 +52,7 @@ var makeApp = function(config, callback) {
     var params,
         defaults = {port: 31337,
                     hostname: "127.0.0.1",
+                    driver: "disk",
                     site: "pump.io",
                     sockjs: true,
                     debugClient: false,


### PR DESCRIPTION
The README claims that the databank driver is set to "disk" by
default. Make it so.

With this small change, one can now get to a working instance by "git clone ... ; npm install ; npm start" (assuming you have a user-writable `/var/lib/diskdatabank`). No need to configure anything to get a test instance going.
