### PR TITLE
"TypeError: Arguments to path.join must be strings" with node v10.3 on uploading avatar

### DIFF
--- a/routes/uploads.js
+++ b/routes/uploads.js
@@ -81,7 +81,7 @@ var sendFile = function(req, res, slug, next) {
                 if (!cutils.modified(req, res)) {
                     cutils.notModified(res);
                 } else {
-                    res.sendfile(fullpath);
+                    res.sendfile(fullpath, {root:'/'});
                 }
             }
         }


### PR DESCRIPTION
With node v10.3, uploading avatar will throw an uncatched exception "TypeError: Arguments to path.join must be strings" that will eventually stop the server.

Assuming "fullpath" is an absolute path, setting the root to / will fix the error.
