### PR TITLE
Do not assume a connection event will always have a connection.

### DIFF
--- a/lib/pumpsocket.js
+++ b/lib/pumpsocket.js
@@ -316,6 +316,11 @@ var connect = function(app, log) {
     server.provider = app.provider;
 
     server.on("connection", function(conn) {
+	    if (conn === null) {
+	        server.log.info ("Connection event without a connection.");
+	        return;
+	    }
+
         var id = conn.id;
         conn.log = server.log.child({"connection_id": id, component: "sockjs"});
         conn.log.info("Connected");


### PR DESCRIPTION
On my instance "conn" provided by the connection event would sometimes be null (only when running under SSL), which crashes the server.

This change just ignores connection events for which conn is null.
