### PR TITLE
Fix API.md typo

### DIFF
--- a/API.md
+++ b/API.md
@@ -229,7 +229,7 @@ Collection URLs take the following params:
    collection immediately before the specified activity (not
    inclusive). A good way to "scroll back" in a collection.
 * *since*. An activity ID. Will get activities that went into the
-   collection immediately before the specified activity (not
+   collection immediately after the specified activity (not
    inclusive). A good way to get what's new in a collection since you
    last polled it.
 


### PR DESCRIPTION
The "after" collection URL param says "immediately before the specified
activity".  This should be "immediately after the specified activity".
