### PR TITLE
Document the 'type' parameter for client registration.

### DIFF
--- a/API.md
+++ b/API.md
@@ -471,8 +471,10 @@ discover it in the host-meta file with link-rel
 The client registration will accept some of the parameters that OpenID
 does. Here's what it supports:
 
-* *type*
-* *client_id*, *client_secret*: only for updates
+* *type*: one of the values `client_associate` (when registering a client)
+  or `client_update` (when updating the details of a previously-registered
+  client)
+* *client_id*, *client_secret*: only when `type` is set to `client_update`.
 * *contacts*
 * *application_type*
 * *application_name*


### PR DESCRIPTION
The pump.io API documentation says client registration is loosely modelled on the OpenID Dynamic Client Registration specification, still under development, and apparently it includes a required parameter named 'type'. Looking at the current (2013-08-26) version of the OpenID DCR draft spec, it seems that since the pump.io API was drafted, DCR has (a) renamed the 'type' parameter to 'operation' (in revision 14) and (b) deleted the 'operation' parameter (in revision 15), leaving no documentation on what pump.io actually expects this field to contain.
