### PR TITLE
Added clarifying points for hostname and address parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,14 @@ Here are the main configuration keys.
 * *params* Databank driver params; see the databank driver README for
    details on what to put here.
 * *hostname* The hostname of the server. Defaults to "localhost" which
-   doesn't do much for you.
+   doesn't do much for you.  If you want to serve from behind a router, 
+   set this to your public address (IE a domain name or public IP address).
+   Also see [Making changes](#making-changes).
 * *address* The address to listen on. Defaults to `hostname`, which is
    OK for most systems. Use this if you've got some kind of
    load-balancer or NAS or whatever and your local IP doesn't map to
-   the IP of the hostname.
+   the IP of the hostname.  If you are serving from behind a router, set 
+   this to your internal IP address.
 * *port* Port to listen on. Defaults to 31337, which is no good. You
    should listen on 80 or 443 if you're going to have anyone use this.
 * *urlPort* Port to use for generating URLs. Defaults to the same as `port`,


### PR DESCRIPTION
I'm setting pump.io for the first time, and the details that I added here were definitely the biggest points of struggle in the process.

Once I was informed of these differences in IRC, hosting from behind a router made sense to me.

Also, with regards to the Making Changes section, maybe we should reference that section from every parameter that it applies to?  I only added a reference to the hostname section.
