### PR TITLE
Don't use displayName if it's empty (should fix #819)

### DIFF
--- a/lib/model/activity.js
+++ b/lib/model/activity.js
@@ -1117,7 +1117,8 @@ Activity.makeContent = function(props) {
 
     var content,
         nameOf = function(obj) {
-            if (_.has(obj, "displayName")) {
+            if (_.has(obj, "displayName") &&
+               !_.isEmpty(obj, "displayName")) {
                 return obj.displayName;
             } else if (!_.has(obj, "objectType")) {
                 return "an object";


### PR DESCRIPTION
This should fix https://github.com/e14n/pump.io/issues/819, but I've done it blindly, and can't test it ATM.
Hopefully, someone with good knowledge of node.js and pump.io internals can take a look and determine if it's good.

Cheers!
