### PR TITLE
fix #805 - recipients autocomplete

### DIFF
--- a/public/javascript/pump/view.js
+++ b/public/javascript/pump/view.js
@@ -3302,7 +3302,7 @@
                 Pump.ajax({
                     type: "GET",
                     dataType: "json",
-                    url: Pump.fullURL("/api/user/"+user.get("nickname")+"/following?q="+term),
+                    url: Pump.fullURL("/api/user/"+user.get("nickname")+"/following?q="+options.term),
                     success: function(data) {
                         var people = _.map(data.items, function(item) {
                             return {id: item.objectType + ":" + item.id,


### PR DESCRIPTION
Fixes #805, #810, #840 and #890, all the same issue - autocomplete for recipients of a note or picture doesn't work when you start typing a name from beginning. The cause: API search query was mistakenly receiving a term converted to lowercase, but it is case sensitive, causing the query to fail for any capital letters, such as first letter of a name.

Alternative solution: queries could be case insensitive, so that user can type a name without paying attention to capital letters. But that is a design decision, this patch fixes the issue.
