### PR TITLE
fix #901 - text rewrapping on hover

### DIFF
--- a/public/stylesheet/pumpio.css
+++ b/public/stylesheet/pumpio.css
@@ -89,6 +89,10 @@ body {
   margin-bottom: 8px;
 }
 
+.major > .media-body {
+  margin-right: 20px;
+}
+
 .activity-content p:last-child {
   margin-bottom: 0;
 }


### PR DESCRIPTION
Fixes #901 - moving mouse cursor over your own post caused text rewrapping back and forth because CSS didn't anticipate the tiny arrow of Delete menu.
