### PR TITLE
show unshare-button in web-ui

### DIFF
--- a/public/template/responses.utml
+++ b/public/template/responses.utml
@@ -5,7 +5,7 @@
     <a class="favorite" href="#">Like <i class="icon-thumbs-up"></i></a> 
     <% } %>
     <a class="comment" href="#">Comment <i class="icon-comment"></i></a> 
-    <% if (obj.pump_io.shared) { %>
+    <% if (typeof obj.pump_io != "undefined" && obj.pump_io.shared) { %>
     <a class="unshare" href="#">Unshare <i class="icon-remove"></i></a>
     <% } else { %>
     <a class="share" href="#">Share <i class="icon-share-alt"></i></a>


### PR DESCRIPTION
i was wondering why i can't see an "unshare" button.

addShared (from finishers.js) sets "object.pump_io.shared" and not "obj.shared"
