### PR TITLE
Can't follow a certain identi.ca accounts

### DIFF
--- a/lib/model/activityobject.js
+++ b/lib/model/activityobject.js
@@ -1115,7 +1115,8 @@ ActivityObject.validate = function(props) {
                 // maybe it looks like: "upstreamDuplicates":{"0":"http://identi.ca/user/12345"}
                 // #ISSUE 982
                 if(typeof props.upstreamDuplicates[0] == "undefined"){
-                throw new TypeError(uriarrayprop + " is not an array and has no 0 value");
+                 throw new TypeError(uriarrayprop + " is not an array and has no 0 value");
+                } 
             }
 
             if (_.some(props[uriarrayprop], function(str) { return !_.isString(str); })) {


### PR DESCRIPTION
https://github.com/e14n/pump.io/issues/982

some profiles have the value  "upstreamDuplicates" set.
If this is set to:

```
"upstreamDuplicates":{"0":"http://identi.ca/user/12345"}
```

the function throws:

```
Error: Remote OAuth error code 500: TypeError: upstreamDuplicates is not an array
```
