### PR TITLE
if post-a-note has content ask before close

### DIFF
--- a/public/javascript/pump/view.js
+++ b/public/javascript/pump/view.js
@@ -585,6 +585,15 @@
                     Pump.showModal(Cls, {data: {user: Pump.principalUser,
                                                 lists: lists},
                                          ready: function() {
+                                                $('#modal-note').bind('hide', function (e) {
+                                                 if ($('#note-content').val()) {
+                                                    if (window.confirm("Are you sure?")) {
+                                                        $('#modal-note').remove();
+                                                    } else {
+                                                        e.preventDefault();
+                                                    }
+                                                } else $('#modal-note').remove();
+                                               });
                                              stopSpin();
                                          }});
                 }
@@ -2730,6 +2739,7 @@
             "click #send-note": "postNote"
         },
         postNote: function(ev) {
+            $('#modal-note').unbind();
             var view = this,
                 text = view.$('#post-note #note-content').val(),
                 to = view.$('#post-note #note-to').val(),


### PR DESCRIPTION
this prevents to force close (modal backdrop) the post-a-note modal if the textarea has content without asking.
A colleague wrote a long text and accidentally clicked the background.
