### PR TITLE
fix #1023 - description with HTML markup over image

### DIFF
--- a/public/template/lightbox-modal.utml
+++ b/public/template/lightbox-modal.utml
@@ -1,8 +1,8 @@
 <div id="fullImageLightbox" class="lightbox hide fade" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="lightbox-content">
     <img src="<%- (object.fullImage.pump_io && object.fullImage.pump_io.proxyURL) ? object.fullImage.pump_io.proxyURL : object.fullImage.url %>" class="img-polaroid" />
-    <% if (object.content) { %>
-    <div class="lightbox-caption"><p><%- object.content %></p></div>
+    <% if (object.displayName) { %>
+    <div class="lightbox-caption"><p><%- object.displayName %></p></div>
     <% } %>
   </div>
 </div>


### PR DESCRIPTION
Fixes issue #1023. Pop-up images have labels, but there was a bug - instead of the image title, the “content” property was used, which can in this case include long description, often with HTML formating.
