### PR TITLE
Small fix in CSS, to break long contents in multiple lines

### DIFF
--- a/public/stylesheet/pumpio.css
+++ b/public/stylesheet/pumpio.css
@@ -114,6 +114,10 @@ body {
   margin-right: 20px;
 }
 
+.activity-content {
+  word-wrap: break-word;
+}
+
 .activity-content p:last-child {
   margin-bottom: 0;
 }


### PR DESCRIPTION
Rebased version of #1140 since the original author is unresponsive
