### PR TITLE
Fix #526 - Adds a robot.txt file to disallow to /api/

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /api/


### PR DESCRIPTION
This is a resubmission of PR #533 to fix #526. It adds a robots.txt file to prevent search bots poking around in `/api/`.

@strugee