### PR TITLE
Fix close user dropdown when link is clicked

### DIFF
--- a/public/javascript/pump/view.js
+++ b/public/javascript/pump/view.js
@@ -540,7 +540,8 @@
         events: {
             "click #logout": "logout",
             "click #post-note-button": "postNoteModal",
-            "click #post-picture-button": "postPictureModal"
+            "click #post-picture-button": "postPictureModal",
+            "click #fat-menu .dropdown-menu li": "closeDropdown"
         },
         postNoteModal: function() {
             var view = this;
@@ -630,6 +631,10 @@
                 streams.notifications = view.minorStreamView.model;
             }
             return streams;
+        },
+        closeDropdown: function(e) {
+            e.preventDefault();
+            $("#profile-dropdown").dropdown("toggle");
         }
     });
 


### PR DESCRIPTION
Closes: #1271 

Other option is hide all dropdown's on page change

```javascript
Pump.router.on("route", function() {
    // Hide all dropdown open on page change
    $(".dropdown.open").trigger("click");
});
```