### PR TITLE
Expand list of blacklisted nicknames

### DIFF
--- a/lib/nicknameblacklist.js
+++ b/lib/nicknameblacklist.js
@@ -18,4 +18,11 @@
 
 "use strict";
 
-module.exports = ["api", "oauth"];
+module.exports = ["api",
+                  "oauth",
+                  "public",
+                  "robots.txt",
+                  "humans.txt",
+                  ".well-known",
+                  "sitemap.xml",
+                  "favicon.ico"];


### PR DESCRIPTION
All of these conflict with well-known URLs that we use or may use in
the future. It's not hard to imagine us deciding we won't use some of
these, but better to be restrictive now and open it up later, rather
than dealing with someone potentially signing up with one of these
names.