### PR TITLE
Add period and space after owner information

### DIFF
--- a/public/template/layout.jade
+++ b/public/template/layout.jade
@@ -58,6 +58,7 @@ html(lang="en")
               a(href="#{config.ownerURL}") #{config.owner}
             else
               | #{config.owner}
+            |. 
             if config.appendFooter
               | !{config.appendFooter}
         p


### PR DESCRIPTION
This causes it to work better when `appendFooter` is used.

Signed-off-by: Jason Self <j@jxself.org>