### PR TITLE
Fallback text if notifications/messages panel is empty

### DIFF
--- a/public/template/messages.jade
+++ b/public/template/messages.jade
@@ -12,7 +12,7 @@
           small!= activity.content
     if !messages.items.length
       li
-        small="You do not have any message yet"
+        small= "You do not have any message yet"
     li.divider
     li
       a(tabindex="-1", href="/main/messages") All messages

--- a/public/template/messages.jade
+++ b/public/template/messages.jade
@@ -10,7 +10,7 @@
       if _.isObject(activity)
         li
           small!= activity.content
-    if !messages.items.length
+    if messages.items.length === 0
       li
         small You do not have any messages yet
     li.divider

--- a/public/template/messages.jade
+++ b/public/template/messages.jade
@@ -12,7 +12,7 @@
           small!= activity.content
     if !messages.items.length
       li
-        small= "You do not have any message yet"
+        small You do not have any messages yet
     li.divider
     li
       a(tabindex="-1", href="/main/messages") All messages

--- a/public/template/messages.jade
+++ b/public/template/messages.jade
@@ -1,5 +1,5 @@
 .btn-group.dropdown#messages
-  button.btn.dropdown-toggle.btn-small.btn-success(disabled=messages.totalItems <= 0, data-toggle="dropdown", href="#")
+  button.btn.dropdown-toggle.btn-small.btn-success(data-toggle="dropdown", href="#")
     i.icon-envelope.icon-white
     if messages.items.length > 0
       | &nbsp;
@@ -10,9 +10,9 @@
       if _.isObject(activity)
         li
           small!= activity.content
-
-    if messages.items.length > 0
-      li.divider
-
+    if !messages.items.length
+      li
+        small="You do not have any message yet"
+    li.divider
     li
       a(tabindex="-1", href="/main/messages") All messages

--- a/public/template/notifications.jade
+++ b/public/template/notifications.jade
@@ -8,6 +8,6 @@
     each activity in notifications.items
       li
         small!= activity.content
-    if notifications.items.length <= 0
+    if notifications.items.length === 0
       li
         small No notifications... yet!

--- a/public/template/notifications.jade
+++ b/public/template/notifications.jade
@@ -1,5 +1,5 @@
 .btn-group#notifications
-  button.btn.dropdown-toggle.btn-small.btn-success(disabled=notifications.totalItems <= 0, data-toggle="dropdown", href="#")
+  button.btn.dropdown-toggle.btn-small.btn-success(data-toggle="dropdown", href="#")
     i.icon-exclamation-sign.icon-white
     if notifications.items.length > 0
       | &nbsp;
@@ -8,3 +8,6 @@
     each activity in notifications.items
       li
         small!= activity.content
+    if !notifications.items.length
+      li
+        small="No notifications... yet!"

--- a/public/template/notifications.jade
+++ b/public/template/notifications.jade
@@ -10,4 +10,4 @@
         small!= activity.content
     if !notifications.items.length
       li
-        small="No notifications... yet!"
+        small= "No notifications... yet!"

--- a/public/template/notifications.jade
+++ b/public/template/notifications.jade
@@ -8,6 +8,6 @@
     each activity in notifications.items
       li
         small!= activity.content
-    if !notifications.items.length
+    if notifications.items.length <= 0
       li
-        small= "No notifications... yet!"
+        small No notifications... yet!


### PR DESCRIPTION
Fallback text if notifications/messages panel is empty,
disabled button removed because it looks like an error
and displaying alternative text is a normal behavior
in all platforms with notifications panel.

Closes: #1096