### PR TITLE
Fix tight text in main page

### DIFF
--- a/public/template/main-client.jade
+++ b/public/template/main-client.jade
@@ -25,8 +25,8 @@
       .span4
         img.img-rounded(src="images/somefriends.jpg", width="340", height="235")
 
-      div
-        p
-          | Check out the 
-          a(href="https://pumpio.readthedocs.org/en/latest/userguide.html" target="_blank") basic user guide
-          | .
+        div
+          p
+            | Check out the 
+            a(href="https://pumpio.readthedocs.org/en/latest/userguide.html" target="_blank") basic user guide
+            | .


### PR DESCRIPTION
In some resolutions the 'user guide' text in main page looks very tight.

![pump main page](https://ibin.co/3K8Hn0kx2TtL.png)