### PR TITLE
Don't insecurely handle config.secret's absence

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -277,7 +277,7 @@ var makeApp = function(configBase, callback) {
         var dbstore = new DatabankStore(db, log, (config.cleanupSession) ? (config.cleanupSession * workers) : 0);
 
         if (!config.noweb) {
-            session = expressSession({secret: config.secret || "insecure",
+            session = expressSession({secret: config.secret,
                                       store: dbstore,
                                       saveUninitialized: false,
                                       resave: false});


### PR DESCRIPTION
It's much better to just error so the admin fixes it instead of doing something stupid on our own that nobody wants (should want).