### PR TITLE
Fix wrong session validation in uploads

### DIFF
--- a/routes/uploads.js
+++ b/routes/uploads.js
@@ -39,7 +39,7 @@ var send = require("send"),
 var EXPIRES = 365 * 24 * 60 * 60 * 1000;
 
 var addRoutes = function(app, session) {
-    if (app.session) {
+    if (session) {
         app.get("/uploads/*", session, everyAuth, uploadedFile);
     } else {
         app.get("/uploads/*", everyAuth, uploadedFile);

--- a/test/upload-file-test.js
+++ b/test/upload-file-test.js
@@ -188,7 +188,7 @@ suite.addBatch({
                                     assert.ifError(err);
                                 }
                             },
-                            "and we get the file from web interface without login": {
+                            "and we get the file from the web interface without logging in": {
                                 topic: function(doc, feed, pair, cl) {
                                     var cred = makeCred(cl, pair),
                                         browser = new Browser(),
@@ -203,7 +203,7 @@ suite.addBatch({
                                     br.assert.status(403);
                                 }
                             },
-                            "and we login for try get file": {
+                            "and we login and try to get the file": {
                                 topic: function(doc, feed, pair, cl) {
                                     var browser = new Browser(),
                                         callback = this.callback,
@@ -222,7 +222,7 @@ suite.addBatch({
                                     assert.ifError(err);
                                     br.assert.success();
                                 },
-                                "and we get the file from web interface with login": {
+                                "and we get the file from the web interface while logged in": {
                                     topic: function(br, doc, feed, pair, cl) {
                                         var cred = makeCred(cl, pair),
                                             browser = br,


### PR DESCRIPTION
`app.session` instance not exists

before pump 4.x `session` middleware was living in `app` instance > [app.js](https://github.com/pump-io/pump.io/commit/79d2478365bb481606d4fd02e908e9ba59421213)

Closes: #1435