### PR TITLE
Share a note to a specific target

### DIFF
--- a/public/javascript/pump.js
+++ b/public/javascript/pump.js
@@ -532,6 +532,17 @@ if (!window.Pump) {
         return $("<div/>").html(value).text();
     };
 
+    Pump.strToObj = function(str) {
+        var colon = str.indexOf(":"),
+            type = str.substr(0, colon),
+            id = str.substr(colon + 1);
+
+        return new Pump.ActivityObject({
+            id: id,
+            objectType: type
+        });
+    };
+
     // Sets up the initial view and sub-views
 
     Pump.initialContentView = function() {

--- a/public/javascript/pump.js
+++ b/public/javascript/pump.js
@@ -631,6 +631,7 @@ if (!window.Pump) {
     };
 
     Pump.addToStream = function(stream, act, callback) {
+        console.log(act);
         stream.items.create(act, {
             wait: true,
             success: function(act) {

--- a/public/javascript/pump.js
+++ b/public/javascript/pump.js
@@ -631,7 +631,6 @@ if (!window.Pump) {
     };
 
     Pump.addToStream = function(stream, act, callback) {
-        console.log(act);
         stream.items.create(act, {
             wait: true,
             success: function(act) {

--- a/public/javascript/pump/view.js
+++ b/public/javascript/pump/view.js
@@ -1419,30 +1419,22 @@
                 }
             });
         },
-        shareObject: function () {
+        shareObject: function() {
             var view = this;
-            view.showShareModal(view.model, function (err, to) {
-                act = new Pump.Activity({
+            view.showShareModal(view.model, function(err, to) {
+                var act = new Pump.Activity({
                     verb: "share",
                     object: view.model.object.toJSON()
                 });
-                strToObj = function (str) {
-                    var colon = str.indexOf(":"),
-                        type = str.substr(0, colon),
-                        id = str.substr(colon + 1);
-                    return new Pump.ActivityObject({
-                        id: id,
-                        objectType: type
-                    });
-                };
+
                 if (_.isString(to)) {
                     to = to.split(",");
                 }
                 if (to && to.length > 0) {
-                    act.to = new Pump.ActivityObjectBag(_.map(to, strToObj));
+                    act.to = new Pump.ActivityObjectBag(_.map(to, Pump.strToObj));
                 }
                 view.startSpin();
-                Pump.newMajorActivity(act, function (err, act) {
+                Pump.newMajorActivity(act, function(err, act) {
                     if (err) {
                         view.stopSpin();
                         view.showError(err);
@@ -1456,12 +1448,13 @@
                 });
             });
         },
-        showShareModal: function (model, callback) {
+        showShareModal: function(model, callback) {
             var view = this,
                 profile = Pump.principal,
                 lists = profile.lists;
 
-            Pump.fetchObjects([lists], function (err, objs) {
+            Pump.fetchObjects([lists], function(err, objs) {
+                console.log(objs);
                 if (err) {
                     view.showError(err);
                 } else {
@@ -2771,16 +2764,7 @@
                         objectType: "note",
                         content: text
                     }
-                }),
-                strToObj = function(str) {
-                    var colon = str.indexOf(":"),
-                        type = str.substr(0, colon),
-                        id = str.substr(colon+1);
-                    return new Pump.ActivityObject({
-                        id: id,
-                        objectType: type
-                    });
-                };
+                });
 
             if (_.isString(to)) {
                 to = to.split(",");
@@ -2791,11 +2775,11 @@
             }
 
             if (to && to.length > 0) {
-                act.to = new Pump.ActivityObjectBag(_.map(to, strToObj));
+                act.to = new Pump.ActivityObjectBag(_.map(to, Pump.strToObj));
             }
 
             if (cc && cc.length > 0) {
-                act.cc = new Pump.ActivityObjectBag(_.map(cc, strToObj));
+                act.cc = new Pump.ActivityObjectBag(_.map(cc, Pump.strToObj));
             }
 
             view.startSpin();
@@ -2820,7 +2804,7 @@
 
         tagName: "div",
         className: "modal-holder",
-        templateName: 'post-share',
+        templateName: "share-note",
         parts: ["recipient-selector"],
         ready: function() {
             var view = this;
@@ -2830,16 +2814,18 @@
             "click #send-share": "postShare"
         },
         postShare: function(ev) {
-            var view = this;
-            callback = view.options.callback;
-            to = view.$('#share-to').val();
-            view.$el.modal('hide');
+            var view = this,
+                callback = view.options.callback,
+                to = view.$("#share-to").val();
+
+            view.$el.modal("hide");
             view.remove();
             callback(null, to);
         }
     });
 
     Pump.PostPictureModal = Pump.TemplateView.extend({
+
         tagName: "div",
         className: "modal-holder",
         templateName: "post-picture",
@@ -2886,15 +2872,6 @@
                     var stream = Pump.principalUser.majorStream,
                         to = view.$("#post-picture #picture-to").val(),
                         cc = view.$("#post-picture #picture-cc").val(),
-                        strToObj = function(str) {
-                            var colon = str.indexOf(":"),
-                                type = str.substr(0, colon),
-                                id = str.substr(colon+1);
-                            return Pump.ActivityObject.unique({
-                                id: id,
-                                objectType: type
-                            });
-                        },
                         act = new Pump.Activity({
                             verb: "post",
                             object: responseJSON.obj
@@ -2909,11 +2886,11 @@
                     }
 
                     if (to && to.length > 0) {
-                        act.to = new Pump.ActivityObjectBag(_.map(to, strToObj));
+                        act.to = new Pump.ActivityObjectBag(_.map(to, Pump.strToObj));
                     }
 
                     if (cc && cc.length > 0) {
-                        act.cc = new Pump.ActivityObjectBag(_.map(cc, strToObj));
+                        act.cc = new Pump.ActivityObjectBag(_.map(cc, Pump.strToObj));
                     }
 
                     Pump.newMajorActivity(act, function(err, act) {
@@ -3315,17 +3292,8 @@
             minimumInputLength: 2,
             initSelection: function(element, callback) {
                 var val = element.val(),
-                    strToObj = function(str) {
-                        var colon = str.indexOf(":"),
-                            type = str.substr(0, colon),
-                            id = str.substr(colon+1);
-                        return new Pump.ActivityObject({
-                            id: id,
-                            objectType: type
-                        });
-                    },
                     selection = [],
-                    obj = (val && val.length > 0) ? strToObj(val) : null;
+                    obj = (val && val.length > 0) ? Pump.strToObj(val) : null;
 
                 if (obj) {
                     if (obj.id == "http://activityschema.org/collection/public") {

--- a/public/stylesheet/pumpio.css
+++ b/public/stylesheet/pumpio.css
@@ -92,10 +92,16 @@ body {
   margin-top: 25px;
   border-bottom: 1px dotted #EEE;
   padding-bottom: 20px;
+  overflow: visible;
 }
 
 #major-stream .media:first-child {
   margin-top: 1em;
+}
+
+#major-stream .media-body {
+  overflow: visible;
+  margin-left: 75px;
 }
 
 .media-body p.muted:first-child {
@@ -118,6 +124,10 @@ body {
 
 .responses a {
   margin-right: 6px;
+}
+
+.responses .dropdown {
+  display: inline-block;
 }
 
 .responses + p.muted {
@@ -289,5 +299,6 @@ body {
   }
   #major-stream .media-body {
     display: inline;
+    margin-left: 0;
   }
 }

--- a/public/stylesheet/pumpio.css
+++ b/public/stylesheet/pumpio.css
@@ -104,6 +104,10 @@ body {
   margin-left: 75px;
 }
 
+#major-stream .headless .media-body {
+  margin-left: 20px;
+}
+
 .media-body p.muted:first-child {
   line-height: 14px;
   margin-bottom: 8px;
@@ -279,7 +283,7 @@ body {
     padding-top: 0;
   }
   .navbar {
-  position: relative;
+    position: relative;
   }
   .navbar .pull-right .btn-group {
     position: static;

--- a/public/template/recipient-selector.jade
+++ b/public/template/recipient-selector.jade
@@ -1,3 +1,3 @@
-mixin recipient-selector(name, id, label)
+mixin recipient-selector(name, id, label, value)
   label(for=id)= label
-  input(type="hidden", name=name id=id value=name === "cc" ? "collection:#{principal.followers.url}" : "")
+  input(type="hidden", name=name id=id value=value !== undefined ? value : name === "cc" ? "collection:#{principal.followers.url}" : "")

--- a/public/template/responses.jade
+++ b/public/template/responses.jade
@@ -20,5 +20,11 @@
     a.unshare(href="#") Unshare 
       i.fa.fa-times
   else
-    a.share(href="#") Share 
-      i.fa.fa-share
+    .dropdown
+      a.share.dropdown-toggle#share-dropdown(href="#", role="button", data-toggle="dropdown") Share 
+        i.fa.fa-share
+      ul.share-menu.dropdown-menu(role="menu", aria-labelledby="share-dropdown")
+        li
+          a(tabindex="-1", href="#" data-share="now") Share now
+        li
+          a(tabindex="-1", href="#" data-share="to") Share to

--- a/public/template/share-note.jade
+++ b/public/template/share-note.jade
@@ -29,6 +29,6 @@ include ./recipient-selector.jade
     form.form-horizontal#share-note
       fieldset
         div
-+recipient-selector("to", "share-to", "To", ("collection:" +  default_to))
+          +recipient-selector("to", "share-to", "To", ("collection:" +  default_to))
   .modal-footer
-    button.btn.btn-primary#send-note(type="submit") Share
+    button.btn.btn-primary#send-share(type="submit") Share

--- a/public/template/share-note.jade
+++ b/public/template/share-note.jade
@@ -1,0 +1,34 @@
+//- <div id="modal-note" class="modal pump-modal hide fade" tabindex="-1" role="dialog" aria-labelledby="post-label" aria-hidden="true">
+//-   <div class="modal-header">
+//-     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+//-     <h3 id="post-label">Share note from <%- model.actor.displayName %></h3>
+//-   </div>
+//-   <div class="modal-body">
+//-     <form id="post-note" class="form-horizontal">
+//-       <fieldset>
+//-         <div>
+//-           <%= partial("recipient-selector-share", {name: "to", id: "share-to", label: "To"}) %>
+//-         </div>
+//-      </fieldset>
+//-     </form>
+//-   </div>
+//-   <div class="modal-footer">
+//-     <button type="submit" class="btn btn-primary" id="send-share">Share</button>
+//-   </div>
+//- </div>
+include ./recipient-selector.jade
+
+- var default_to = principal.followers.url
+
+.modal.pump-modal.hide.fade#modal-share(tabindex="-1", role="dialog", aria-labelledby="share-label", aria-hidden="true")
+  .modal-header
+    button.close(type="button", data-dismiss="modal", aria-hidden="true") &times;
+    h3#post-label Share note from #{model.actor.displayName}
+
+  .modal-body
+    form.form-horizontal#share-note
+      fieldset
+        div
++recipient-selector("to", "share-to", "To", ("collection:" +  default_to))
+  .modal-footer
+    button.btn.btn-primary#send-note(type="submit") Share

--- a/public/template/share-note.jade
+++ b/public/template/share-note.jade
@@ -1,21 +1,3 @@
-//- <div id="modal-note" class="modal pump-modal hide fade" tabindex="-1" role="dialog" aria-labelledby="post-label" aria-hidden="true">
-//-   <div class="modal-header">
-//-     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-//-     <h3 id="post-label">Share note from <%- model.actor.displayName %></h3>
-//-   </div>
-//-   <div class="modal-body">
-//-     <form id="post-note" class="form-horizontal">
-//-       <fieldset>
-//-         <div>
-//-           <%= partial("recipient-selector-share", {name: "to", id: "share-to", label: "To"}) %>
-//-         </div>
-//-      </fieldset>
-//-     </form>
-//-   </div>
-//-   <div class="modal-footer">
-//-     <button type="submit" class="btn btn-primary" id="send-share">Share</button>
-//-   </div>
-//- </div>
 include ./recipient-selector.jade
 
 - var default_to = principal.followers.url


### PR DESCRIPTION
The same functionality of: https://github.com/pump-io/pump.io/pull/991 (with rebase to master and refactor), but with a drop-down share menu with two options, 'now' like current behavior and 'to' with specific target.

**Share Menu**
![menu](https://ibin.co/3duIk6uzdBWD.png)

**Share Modal**
![modal](https://ibin.co/3duJ5eaSU4Ti.png)