### PR TITLE
Improve infinite scroll

### DIFF
--- a/public/javascript/pump.js
+++ b/public/javascript/pump.js
@@ -83,7 +83,7 @@ if (!window.Pump) {
             Pump.setupSocket();
         }
 
-        Pump.setupInfiniteScroll();
+        Pump.infiniteScroll = new Pump.InfiniteScrollView({el: $(".infinite-scroll")});
 
         if (Pump.principalUser) {
             Pump.principalUser = Pump.User.unique(Pump.principalUser);
@@ -468,36 +468,6 @@ if (!window.Pump) {
                 }
             });
         }
-    };
-
-    Pump.setupInfiniteScroll = function() {
-
-        var didScroll = false;
-
-        // scroll fires too fast, so just use the handler
-        // to set a flag, and check that flag with an interval
-
-        // From http://ejohn.org/blog/learning-from-twitter/
-
-        $(window).scroll(function() {
-            didScroll = true;
-        });
-
-        setInterval(function() {
-            var streams;
-            if (didScroll) {
-                didScroll = false;
-                if ($(window).scrollTop() >= $(document).height() - $(window).height() - 10) {
-                    streams = Pump.getStreams();
-                    if (streams.major && streams.major.nextLink()) {
-                        Pump.body.startLoad();
-                        streams.major.getNext(function(err) {
-                            Pump.body.endLoad();
-                        });
-                    }
-                }
-            }
-        }, 250);
     };
 
     // XXX: this is cheeseball.

--- a/public/stylesheet/pumpio.css
+++ b/public/stylesheet/pumpio.css
@@ -79,6 +79,22 @@ body {
   line-height: 15px;
 }
 
+/* infinite-scroll */
+
+.infinite-scroll {
+  width: 100%;
+}
+
+.infinite-scroll .btn {
+  width: 100px;
+  margin: 0 auto;
+  display: none;
+}
+
+.infinite-scroll .visible {
+  display: block;
+}
+
 /* modals */
 
 .modal-body {

--- a/public/template/lib/layout.pug
+++ b/public/template/lib/layout.pug
@@ -48,6 +48,12 @@ html(lang="en")
       #content
         block body
 
+      .infinite-scroll
+        .loading
+        button.btn.btn-default.primary.retry(type="button")
+          span.hidden-phone Retry 
+          i.fa.fa-refresh
+          
       hr
 
       footer


### PR DESCRIPTION
This PR improve performance and UI/UX

- Only listen `scroll` event without additional interval
- Send request only on scroll down
- Prevent multiple requests
- Allow retry by the user if exist some error (like network connection error)
- Send the infinite scroll logic to the view

Related #1462


**Some screenshots:**
![image](https://user-images.githubusercontent.com/14242544/31732087-d7b170b2-b3fc-11e7-90f9-6b07d2c1275b.png)
