### PR TITLE
Fix get credentials for socket

### DIFF
--- a/lib/pumpsocket.js
+++ b/lib/pumpsocket.js
@@ -100,7 +100,7 @@ var connect = function(app, appServer, log) {
         rise = function(conn, message) {
 
             var client,
-                params = _.zipObject(message.parameters);
+                params = _.fromPairs(message.parameters);
 
             conn.log.debug({riseMessage: message}, "Client rose to challenge");
 
@@ -129,7 +129,7 @@ var connect = function(app, appServer, log) {
                         conn.user = user;
                         conn.client = client;
                         conn.write(JSON.stringify({cmd: "authenticated",
-                           user: user.nickname}));
+                                                   user: user.nickname}));
                     }
                 });
             } else {
@@ -151,7 +151,7 @@ var connect = function(app, appServer, log) {
             }
         },
         checkSignature = function(message, client, token, cb) {
-            var params = _.zipObject(message.parameters),
+            var params = _.fromPairs(message.parameters),
                 oa = new oauth.OAuth(null,
                                      null,
                                      params.oauth_consumer_key,
@@ -184,7 +184,7 @@ var connect = function(app, appServer, log) {
             }
         },
         validateClient = function(message, cb) {
-            var params = _.zipObject(message.parameters),
+            var params = _.fromPairs(message.parameters),
                 client;
             Step(
                 function() {
@@ -215,7 +215,7 @@ var connect = function(app, appServer, log) {
             );
         },
         validateUser = function(message, cb) {
-            var params = _.zipObject(message.parameters),
+            var params = _.fromPairs(message.parameters),
                 client,
                 token,
                 user;
@@ -237,7 +237,7 @@ var connect = function(app, appServer, log) {
                     if (err) throw err;
                     if (!result) throw new Error("Seen this nonce before!");
                     server.provider.applicationByConsumerKey(params.oauth_consumer_key,
-                                                           this);
+                                                             this);
                 },
                 function(err, application) {
                     if (err) throw err;


### PR DESCRIPTION
use `_.fromPairs` instead `_.zipObject` for get same behavior of `underscore.object`,  because are pairs arrays.

Closes: #1474