### PR TITLE
Fix unshare post

### DIFF
--- a/lib/model/activity.js
+++ b/lib/model/activity.js
@@ -685,7 +685,34 @@ Activity.prototype.applyUnshare = function(callback) {
             if (err) throw err;
             share.del(this);
         },
-        callback
+        function(err) {
+            if (err) throw err;
+            Activity.search({
+                "verb": "share",
+                "actor.id": act.actor.id,
+                "object.id": act.object.id
+            }, this);
+        },
+        function(err, activities) {
+            if (err) throw err;
+            var group = this.group();
+
+            if (_.isArray(activities)) {
+                activities.forEach(function(shareAct) {
+                    // This is AS2
+                    shareAct.object = {
+                        objectType: "Tombstone",
+                        deleted: Stamper.stamp()
+                    };
+                    shareAct.efface(group());
+                });
+            } else {
+                this();
+            }
+        },
+        function(err, results) {
+            callback(err, null);
+        }
     );
 };
 

--- a/public/javascript/pump/view.js
+++ b/public/javascript/pump/view.js
@@ -1443,6 +1443,7 @@
         },
         unshareObject: function() {
             var view = this,
+                model = view.model,
                 act = new Pump.Activity({
                     verb: "unshare",
                     object: view.model.object.toJSON()
@@ -1455,11 +1456,21 @@
                     view.stopSpin();
                     view.showError(err);
                 } else {
-                    view.$(".unshare")
-                        .removeClass("unshare")
-                        .addClass("share")
-                        .html("Share <i class=\"fa fa-share\"></i>");
+                    var shared = view.$(".unshare"),
+                        original = $("[data-object-id='" +
+                                     act.object.id + "'] .unshare");
+
+                    $.each([shared, original], function(index, el) {
+                        el.removeClass("unshare")
+                            .addClass("share")
+                            .html("Share <i class=\"fa fa-share\"></i>");
+                    });
+
                     Pump.addMinorActivity(act);
+                    // Remove from the list
+                    view.remove();
+                    // Remove the model from the client-side collection
+                    model.collection.remove(model.id);
                 }
             });
         },

--- a/public/template/major-activity.jade
+++ b/public/template/major-activity.jade
@@ -11,7 +11,7 @@ unless object.deleted
             img.img-rounded.media-object(src=(author.image.pump_io && author.image.pump_io.proxyURL) ? author.image.pump_io.proxyURL : author.image.url, width="64", height="64")
           else
             img.img-rounded.media-object(src="/images/default.png", width="64", height="64")
-      .media-body
+      .media-body(data-object-id="#{object.id}")
         if object.displayName
           h4.media-heading!= object.displayName
 


### PR DESCRIPTION
This PR implement similar behavior of [Activity Delete](http://w3c.github.io/activitypub/#delete-activity-outbox) on `ActivityPub`.

@strugee if you think this PR will be a good solution tell me and I will add the unit tests.

The problem is the current `share` behavior, this is only a reference to original Object note, but should be a new `Object`and reference the share post by `upstreamDuplicates` (this is remove in AS2) or `context`, example in AS1:

```json
{
    "verb": "share",
    "object": {
        "objectType": "note",
        "id": "http://...",
        "content": "This is Great!!",
        "author": {...},
        "published":  "...",
        "context": "http://original/note/...",
  }
}
```

### PRO
Is more easy to manage the object and the user can share multiples times the same post, and can add additional content, normally the user liked add a opinion when share something.

### CONT
This behavior for comment will change, because are independent object and has your own replies, if you want keep the current behavior will need change the replied behavior for shares posts.

### Note
Activitystreams 2.0 no has `Share` activity.