### PR TITLE
[WIP] Switch to jsonlint2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dependency-check": "^2.8.0",
     "jscs": "^3.0.3",
     "jshint": "^2.9.2",
-    "jsonlint": "^1.6.2",
+    "jsonlint2": "^1.7.0",
     "lcov-result-merger": "^1.2.0",
     "node-mocks-http": "^1.6.1",
     "nyc": "^11.2.1",


### PR DESCRIPTION
`jsonlint` is unmaintained and broken due to npm registry changes; see zaach/jsonlint#105

Closes #1529 

I still need to update `package-lock.json` before this can be merged, self-assigning in an attempt not to forget.