### PR TITLE
Validate socket if a browser support or a connection problem

### DIFF
--- a/public/javascript/pump/socket.js
+++ b/public/javascript/pump/socket.js
@@ -28,6 +28,7 @@
 
     var _socket = {
         reconnecting: false,
+        firstConnection: true,
         retryTimeout: 30000,
         retryAttempts: 0
     };
@@ -132,6 +133,7 @@
                 _socket.retryTimer = null;
             }
             _socket.reconnecting = false;
+            _socket.firstConnection = true;
             _socket.retryAttempts = 0;
         };
 
@@ -164,10 +166,16 @@
                 _socket.retryTimer = null;
             }
 
-            // No more attempts if all transports failed
-            if (error.code === 2000) {
-                Pump.error("Sorry! Your browser doesn't support realtime.");
-                Pump.debug(error);
+            // Let's make sure it's an error browser support or a connection problem
+            if (error.code === 2000 && _socket.retryAttempts > 10) {
+                // No more attempts if all transports failed
+                if (!_socket.error) {
+                    // Show alert only one time
+                    _socket.error = error;
+                    Pump.error(_socket.firstConnection ? "You seem to be offline! Realtime is disabled." :
+                               "Sorry! Your browser doesn't support realtime.");
+                    Pump.debug(error);
+                }
                 return;
             }
 


### PR DESCRIPTION
After some test when the user has a long time disconnected show an error of transports, I add a validation for that ([previously removed](https://github.com/vxcamiloxv/pump.io/blob/9faa5cd8daba7b704a7f3e34abd60aafc7fba7a9/public/javascript/pump/socket.js#L168)) to verify if an error about browser support or a connection problem.

**error:**

![screenshot-2018-04-15_11-58-41](https://user-images.githubusercontent.com/14242544/38813195-f24a130e-4153-11e8-824e-77033b023bed.png)
