### PR TITLE
handle response with a code of error as HTTPError instance

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -663,7 +663,13 @@ var makeApp = function(configBase, callback) {
         });
 
         app.use(function(err, req, res, next) {
+            if (_.get(err, "statusCode") >= 400) {
+                var message = err.description || (typeof err.data === "string" && err.data);
+                err = new HTTPError(message, err.statusCode);
+            }
+
             log.error({err: err, req: req}, err.message);
+
             if (err instanceof HTTPError) {
                 if (req.xhr || req.originalUrl.substr(0, 5) === "/api/") {
                     res.status(err.code).json({error: err.message});
@@ -679,8 +685,6 @@ var makeApp = function(configBase, callback) {
                 next(err);
             }
         });
-
-
 
         Step(
             function() {


### PR DESCRIPTION
In some cases, some response error comes without HTTPError instance like [https://github.com/pump-io/pump.io/blob/master/routes/web.js#L247](routes/web.js#L247) and web client shows: [Object Object].

So this PR extends the error handler to convert the generic error response to HTTPError instance.

related: https://github.com/pump-io/pump.io/issues/1442

**Before change:**
![screenshot-2018-04-16_15-04-02](https://user-images.githubusercontent.com/14242544/38833994-b51c9bc6-418c-11e8-9bc8-dc1f80913753.png)

**After change:**

![screenshot-2018-04-16_15-05-46](https://user-images.githubusercontent.com/14242544/38834004-baec40b0-418c-11e8-85f5-0578aa04157a.png)
