### PR TITLE
Remove reference to dead site http://openfarmgame.com

### DIFF
--- a/public/template/welcome.jade
+++ b/public/template/welcome.jade
@@ -12,9 +12,7 @@ ul
     strong= (profile.id && profile.id.substr(0, 5) === 'acct:') ? profile.id.substr(5) : profile.id
     | . You can use it with 
     a(href="https://pumpio.readthedocs.org/en/latest/clients.html") pump.io-enabled applications
-    | . Try it out on 
-    a(href="http://openfarmgame.com/") Open Farm Game
-    | .
+    | . 
 
 p
   | This message will stay in your inbox so you can refer back. Check out the 

--- a/public/template/welcome.jade
+++ b/public/template/welcome.jade
@@ -12,7 +12,7 @@ ul
     strong= (profile.id && profile.id.substr(0, 5) === 'acct:') ? profile.id.substr(5) : profile.id
     | . You can use it with 
     a(href="https://pumpio.readthedocs.org/en/latest/clients.html") pump.io-enabled applications
-    | . 
+    | .
 
 p
   | This message will stay in your inbox so you can refer back. Check out the 


### PR DESCRIPTION
The site is dead and it has a lot of advertisement, looks like spam and is not good invite the user a spam page.

closes: #1585