### PR TITLE
Fix "upstreamDuplicates is not an array" with identi.ca people

### DIFF
--- a/lib/model/activityobject.js
+++ b/lib/model/activityobject.js
@@ -1113,6 +1113,17 @@ ActivityObject.validate = function(props) {
 
     _.each(uriarrayprops, function(uriarrayprop) {
         if (_.has(props, uriarrayprop)) {
+            // Deal with malformed identi.ca data; see issue #801
+            if (_.isObject(props[uriarrayprop]) &&
+                uriarrayprop === "upstreamDuplicates" &&
+                // Check that all the prop names are really numbers
+                Object.keys(props[uriarrayprop]).map(el => !_.isNaN(Number(el))).reduce((a, b) => a && b))
+            {
+                // XXX Object.values when we drop Node 6
+                // XXX Ordering isn't guaranteed but I *think* this is okay? Since this prop isn't *really* ordered?
+                props[uriarrayprop] = _.values(props[uriarrayprop]);
+            }
+
             if (!_.isArray(props[uriarrayprop])) {
                 throw new TypeError(uriarrayprop + " is a " + typeof props[uriarrayprop] + ", not an array");
             }

--- a/test/activityobject-validation-test.js
+++ b/test/activityobject-validation-test.js
@@ -374,6 +374,27 @@ suite.addBatch({
                 assert.ifError(err);
             }
         },
+        "and we try to ensureObject with an identi.ca upstreamDuplicates object": {
+            topic: function(ActivityObject) {
+                var props = {
+                        id: "urn:uuid:cb8e1f0c-898d-45e5-b155-5d3e1bf0be72",
+                        objectType: "person",
+                        upstreamDuplicates: {0: "http://identi.ca/user/1"}
+                    };
+
+                ActivityObject.ensureObject(props, this.callback);
+            },
+            "it works": function(err, obj) {
+                assert.ifError(err);
+            },
+            "it patched up the data": function(err, obj) {
+                assert.isObject(obj);
+                assert.isArray(obj.upstreamDuplicates);
+                assert.equal(obj.upstreamDuplicates.length, 1);
+                assert.isString(obj.upstreamDuplicates[0]);
+                assert.equal(obj.upstreamDuplicates[0], "http://identi.ca/user/1");
+            }
+        },
         "and we try to ensureObject with non-string member of upstreamDuplicates": {
             topic: function(ActivityObject) {
                 var callback = this.callback,


### PR DESCRIPTION
Fixes #801. @ian-kelling, mind trying this branch on your instance since you seem to be running alphas anyway? If you're using npm to install you can switch to this branch with `npm install -g pump-io/pump.io#upstreamduplicates-is-not-an-array`.