### PR TITLE
Reduce the amount of code we load as root

### DIFF
--- a/bin/pump
+++ b/bin/pump
@@ -90,8 +90,7 @@ var cluster = require("cluster"),
            .alias("version", "v")
            .version()
            .argv,
-    Dispatch = require("../lib/dispatch"),
-    makeApp = require("../lib/app").makeApp;
+    Dispatch = require("../lib/dispatch");
 
 // We first get config files and launch some cluster apps
 
@@ -257,6 +256,9 @@ var launchApps = function(configBase) {
         });
 
     } else {
+
+        // We load this down here instead of at the top so we don't implicitly execute all this code as root
+        var makeApp = require("../lib/app").makeApp;
 
         makeApp(configBase, function(err, appServer) {
             if (err) {


### PR DESCRIPTION
Fixes #1555. This is particularly important since Node's require() has to actively execute each module required, and we don't want just any module in the dep tree to be able to run arbitrary code as root on the administrator's system.

As a bonus, this improves startup performance; `time node -r ./lib/app -e true` reports 3.341s total whereas `time node -e true` reports only 0.092s total. That means we shaved off a little under three and a half seconds from startup.