### PR TITLE
Comment page improvements

### DIFF
--- a/public/javascript/pump/view.js
+++ b/public/javascript/pump/view.js
@@ -1540,10 +1540,17 @@
             "click .close-btn": "cancelComment"
         },
         ready: function() {
-            var view = this;
+            var view = this,
+                orig = view.options.original;
+
+            if (orig.inReplyTo) {
+                $(view.el).prepend('<div class="alert">Your comment will appear on the original post.</div>');
+            }
+
             view.$('textarea[name="content"]').wysihtml5({
                 customTemplates: Pump.wysihtml5Tmpl
             });
+
         },
         cancelComment: function() {
             var view = this,
@@ -1571,7 +1578,7 @@
                     }
                 });
 
-            act.object.inReplyTo = orig;
+            act.object.inReplyTo = orig.inReplyTo || orig;
 
             view.startSpin();
 

--- a/public/template/lib/responses.jade
+++ b/public/template/lib/responses.jade
@@ -11,9 +11,8 @@
 
   //- Comment button
 
-  unless obj.objectType == "comment"
-    a.comment(href="#") Comment 
-      i.fa.fa-comment
+  a.comment(href="#") Comment 
+    i.fa.fa-comment
 
   //- Share/unshare button
 


### PR DESCRIPTION
* Don't show the reply button on comment pages, to discourage commenting on a comment; see #1645
* Show the original post for comments, to encourage replying to that instead; see #1644

This is ready to go in, but I wanted to get feedback on the design. Here's one that's in reply to a note; notice how the note has been truncated because it's over 80 characters:

![screenshot_2019-02-18_02-39-51](https://user-images.githubusercontent.com/911174/52935175-b0d47c00-3326-11e9-8e76-dc65d248b21e.png)

And here's an image with a title and no caption:

![screenshot_2019-02-18_02-38-36](https://user-images.githubusercontent.com/911174/52935261-ea0cec00-3326-11e9-8904-0087e83178b4.png)

The "_(Image)_" placeholder is intentional; I thought putting the actual image in the page would steal focus, take up too much space, etc...

If there's a title, it's always shown. Same with content. If there's no content nothing special happens unless it's an image, in which case it gets "_(Image)_".