### PR TITLE
Add support to Node 10,12 and 13 drop support to 4 -> 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,29 +16,28 @@ services:
   - docker
 stages:
   - name: test
-    if: (type = pull_request) OR (head_branch = master) OR (head_branch = beta)
+    if: type = pull_request OR branch =~ /^(master|beta)$/
   - name: docker-build
-    if: (tag =~ ^v) OR (head_branch = master) OR (head_branch = beta)
-
-before_script:
-  - "./test/hosts.sh"
+    if: type = cron OR tag =~ ^v OR (type = push AND branch =~ /^(master|beta)$/)
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq graphicsmagick
   - npm install -g npm@6
   - npm --version
+before_script:
+  - "./test/hosts.sh"
 after_script:
   # The coverage data from as-root tests is root:root but not world-readable
   - sudo chown -R $(whoami) coverage
   - npm run test:report-coverage
+script:
+  - npm test
+  - npm run test:install
+  - sudo sh -c 'export PATH=\"'\"$(dirname $(which node)):$PATH\"'\" && npm run test:root'
 jobs:
   include:
-    - stage: test
-      script:
-        - npm test
-        - npm run test:install
-        - sudo sh -c 'export PATH=\"'\"$(dirname $(which node)):$PATH\"'\" && npm run test:root'
     - stage: docker-build
+      name: "Docker Build"
       node_js: '12'
       script:
         - if ./util/docker-candidacy.sh; then export DOCKER_CANDIDATE=true; else export DOCKER_CANDIDATE=false; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: node_js
 node_js:
-  - "6"
-  # Note: docker-candidacy.sh chooses 8 as the version to run Docker builds.
-  # That's pretty arbitrary, but I had to pick something. When you remove this
-  # from the build matrix, be sure to adjust that script too.
-  - "8"
-  - "9"
+  - "10"
+  - "12"
+  - "13"
 dist: trusty
 env:
   - CXX=g++-4.8
@@ -17,12 +14,12 @@ addons:
       - g++-4.8
 services:
   - docker
-script:
-  - if ./util/docker-candidacy.sh; then export DOCKER_CANDIDATE=true; else export DOCKER_CANDIDATE=false; fi
-  - echo 'DOCKER_CANDIDATE='$DOCKER_CANDIDATE
-  - if $DOCKER_CANDIDATE; then ./util/build-docker.sh; fi
-  - if [ $TRAVIS_EVENT_TYPE = cron ]; then travis_terminate 0; fi
-  - "(npm test || npm test) && npm run test:install && sudo sh -c 'export PATH=\"'\"$(dirname $(which node)):$PATH\"'\" && npm run test:root'"
+stages:
+  - name: test
+    if: (type = pull_request) OR (head_branch = master) OR (head_branch = beta)
+  - name: docker-build
+    if: (tag =~ ^v) OR (head_branch = master) OR (head_branch = beta)
+
 before_script:
   - "./test/hosts.sh"
 before_install:
@@ -34,6 +31,20 @@ after_script:
   # The coverage data from as-root tests is root:root but not world-readable
   - sudo chown -R $(whoami) coverage
   - npm run test:report-coverage
+jobs:
+  include:
+    - stage: test
+      script:
+        - npm test
+        - npm run test:install
+        - sudo sh -c 'export PATH=\"'\"$(dirname $(which node)):$PATH\"'\" && npm run test:root'
+    - stage: docker-build
+      node_js: '12'
+      script:
+        - if ./util/docker-candidacy.sh; then export DOCKER_CANDIDATE=true; else export DOCKER_CANDIDATE=false; fi
+        - echo 'DOCKER_CANDIDATE='$DOCKER_CANDIDATE
+        - if $DOCKER_CANDIDATE; then ./util/build-docker.sh; fi
+        - if [ $TRAVIS_EVENT_TYPE = cron ]; then travis_terminate 0; fi
 notifications:
   email: false
   webhooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ You cannot upgrade to this release with a zero-downtime restart.
 
 ### Added
 
-* Support Node 10, 12 and 13
+* Support Node.js 10, 12 and 13
 * The master process now listens on a control socket controllable by `pumpctl(8)`; see `pump.socket(7)` for protocol documentation (#1643)
 * Ship an `npm-shrinkwrap.json` file with the package, ensuring that everyone gets the same version of all dependencies
 * Public endpoints will now content-negotiate ActivityStreams 2.0
@@ -44,6 +44,7 @@ You cannot upgrade to this release with a zero-downtime restart.
 * Internal test suite refactoring
 * "Settings" is renamed to "Profile" in the web UI (#1680)
 * Docker images automatically set `NODE_ENV=production`
+* Docker images now use Node.js 12
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ You cannot upgrade to this release with a zero-downtime restart.
 
 ### Added
 
-* Support Node 9
+* Support Node 10, 12 and 13
 * The master process now listens on a control socket controllable by `pumpctl(8)`; see `pump.socket(7)` for protocol documentation (#1643)
 * Ship an `npm-shrinkwrap.json` file with the package, ensuring that everyone gets the same version of all dependencies
 * Public endpoints will now content-negotiate ActivityStreams 2.0
@@ -62,7 +62,7 @@ You cannot upgrade to this release with a zero-downtime restart.
 
 ### Breaking 
 
-* Drop support for Node.js 4, 5, and 7 (#1502)
+* Drop support for Node.js 4 to 9 (#1502)
 * Extract the CLI client tools to pump.io-cli and drop from this package (#381)
 * Reorganize Jade files to reduce npm package size (affects custom templates) (#1457)
 * Upgrade from jade@1 to pug@2 (affects custom templates) (#1580)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -538,6 +538,12 @@
         }
       }
     },
+    "base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI=",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -2824,6 +2830,12 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
       "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
     },
+    "ipv6-normalize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ipv6-normalize/-/ipv6-normalize-1.0.1.tgz",
+      "integrity": "sha1-GzJYKQ02X6gyOeiZB93kWS52IKg=",
+      "dev": true
+    },
     "is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -3827,6 +3839,12 @@
         "range-parser": "^1.2.0",
         "type-is": "^1.6.14"
       }
+    },
+    "nodemailer": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.5.tgz",
+      "integrity": "sha512-NH7aNVQyZLAvGr2+EOto7znvz+qJ02Cb/xpou98ApUt5tEAUSVUxhvHvgV/8I5dhjKTYqUw0nasoKzLNBJKrDQ==",
+      "dev": true
     },
     "nomnom": {
       "version": "1.8.1",
@@ -6292,6 +6310,17 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
+    },
+    "smtp-server": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/smtp-server/-/smtp-server-3.6.0.tgz",
+      "integrity": "sha512-DVEVWzL4s1GWzAs4+6rbhNZpAn61+V8l4b7R8zHLAW2jmlwKz9IKQmdgm5sNruCRnS01BYyitI98vJo7LDnXfg==",
+      "dev": true,
+      "requires": {
+        "base32.js": "0.1.0",
+        "ipv6-normalize": "1.0.1",
+        "nodemailer": "6.4.5"
+      }
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5773,12 +5773,6 @@
       "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
       "dev": true
     },
-    "rai": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.12.tgz",
-      "integrity": "sha1-jM/QFND5YIYw3XPBm45LBXdUpqY=",
-      "dev": true
-    },
     "ramda": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
@@ -6294,16 +6288,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
-    "simplesmtp": {
-      "version": "0.3.35",
-      "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.35.tgz",
-      "integrity": "sha1-AXseuLJjF6w20qKoqTJjGIBzagM=",
-      "dev": true,
-      "requires": {
-        "rai": "~0.1.11",
-        "xoauth2": "~0.1.8"
-      }
     },
     "slash": {
       "version": "1.0.0",
@@ -7569,12 +7553,6 @@
       "version": "0.1.19",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
       "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
-    },
-    "xoauth2": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz",
-      "integrity": "sha1-uRb/EOz7VDIPFvJKPpdRIGU6sNI=",
-      "dev": true
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "proxyquire": "2.0.0",
     "pug-lint": "^2.5.0",
     "rimraf": "^2.6.1",
-    "simplesmtp": "^0.3.35",
+    "smtp-server": "^3.6.0",
     "vows": "^0.8.1",
     "xml2js": "^0.4.17",
     "zombie": "^5.0.7"

--- a/package.json
+++ b/package.json
@@ -129,8 +129,8 @@
   ],
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6 <=9",
-    "npm": ">=2"
+    "node": ">=10",
+    "npm": ">=5"
   },
   "greenkeeper": {
     "commitMessages": {

--- a/test/app-e2e-test.js
+++ b/test/app-e2e-test.js
@@ -64,6 +64,7 @@ suite.addBatch({
                           hostname: "localhost",
                           driver: tc.driver,
                           params: tc.params,
+                          secret: "real secret",
                           nologger: true,
                           sockjs: false
                          },

--- a/test/email-notification-e2e-test.js
+++ b/test/email-notification-e2e-test.js
@@ -21,7 +21,6 @@
 var assert = require("assert"),
     vows = require("vows"),
     _ = require("lodash"),
-    simplesmtp = require("simplesmtp"),
     oauthutil = require("./lib/oauth"),
     apputil = require("./lib/app"),
     httputil = require("./lib/http"),
@@ -34,6 +33,7 @@ var assert = require("assert"),
     registerEmail = oauthutil.registerEmail,
     withAppSetup = apputil.withAppSetup,
     setupAppConfig = apputil.setupAppConfig,
+    createSmtpServer = emailutil.createSmtpServer,
     oneEmail = emailutil.oneEmail,
     confirmEmail = emailutil.confirmEmail;
 
@@ -48,13 +48,13 @@ var userCred = function(cl, user) {
 
 var suite = vows.describe("email notifications");
 
-var registerAndConfirm = function(smtp, cl, email, nickname, password, callback) {
+var registerAndConfirm = function(cl, email, nickname, password, callback) {
 
     var user;
 
     Step(
         function() {
-            oneEmail(smtp, email, this.parallel());
+            oneEmail(email, this.parallel());
             registerEmail(cl, nickname, password, email, this.parallel());
         },
         function(err, message, results) {
@@ -76,20 +76,22 @@ suite.addBatch({
     "When we set up the app": {
         topic: function() {
             var callback = this.callback,
-                smtp = simplesmtp.createServer({disableDNSValidation: true});
+                smtp = createSmtpServer();
             Step(
                 function() {
                     smtp.listen(1623, this);
                 },
                 function(err) {
                     if (err) throw err;
-                    setupAppConfig({hostname: "localhost",
-                                    port: 4815,
-                                    requireEmail: true,
-                                    smtpserver: "localhost",
-                                    smtpport: 1623
-                                   },
-                                   this);
+                    setupAppConfig({
+                        hostname: "localhost",
+                        port: 4815,
+                        requireEmail: true,
+                        smtpserver: "localhost",
+                        smtpport: 1623,
+                        smtpuser: "smtpuser",
+                        smtppass: "smtppass"
+                    }, this);
                 },
                 function(err, app) {
                     if (err) {
@@ -105,7 +107,7 @@ suite.addBatch({
                 app.close();
             }
             if (smtp) {
-                smtp.end(function(err) {});
+                smtp.close();
             }
         },
         "it works": function(err, app, smtp) {
@@ -123,8 +125,8 @@ suite.addBatch({
                 topic: function(cl, app, smtp) {
                     Step(
                         function() {
-                            registerAndConfirm(smtp, cl, "tony@pump.test", "tony", "you*can*tell", this.parallel());
-                            registerAndConfirm(smtp, cl, "stephanie@pump.test", "stephanie", "luv2dance", this.parallel());
+                            registerAndConfirm(cl, "tony@pump.test", "tony", "you*can*tell", this.parallel());
+                            registerAndConfirm(cl, "stephanie@pump.test", "stephanie", "luv2dance", this.parallel());
                         },
                         this.callback
                     );
@@ -150,12 +152,10 @@ suite.addBatch({
 
                         Step(
                             function() {
-                                oneEmail(smtp, "stephanie@pump.test", this.parallel());
+                                oneEmail("stephanie@pump.test", this.parallel());
                                 httputil.postJSON(url, cred, act, this.parallel());
                             },
-                            function(err, message, body, response) {
-                                callback(err, message, body);
-                            }
+                            callback
                         );
                     },
                     "it works": function(err, message, body) {

--- a/test/plugin-e2e-test.js
+++ b/test/plugin-e2e-test.js
@@ -54,6 +54,7 @@ suite.addBatch({
                           hostname: "localhost",
                           driver: tc.driver,
                           params: tc.params,
+                          secret: "real secret",
                           nologger: true,
                           sockjs: false,
                           plugins: ["../test/lib/plugin"]

--- a/test/register-email-required-e2e-test.js
+++ b/test/register-email-required-e2e-test.js
@@ -21,7 +21,6 @@
 var assert = require("assert"),
     vows = require("vows"),
     _ = require("lodash"),
-    simplesmtp = require("simplesmtp"),
     oauthutil = require("./lib/oauth"),
     apputil = require("./lib/app"),
     httputil = require("./lib/http"),
@@ -35,6 +34,7 @@ var assert = require("assert"),
     withAppSetup = apputil.withAppSetup,
     setupAppConfig = apputil.setupAppConfig,
     oneEmail = emailutil.oneEmail,
+    createSmtpServer = emailutil.createSmtpServer,
     confirmEmail = emailutil.confirmEmail;
 
 var makeCred = function(cl, pair) {
@@ -54,20 +54,22 @@ suite.addBatch({
     "When we set up the app": {
         topic: function() {
             var callback = this.callback,
-                smtp = simplesmtp.createServer({disableDNSValidation: true});
+                smtp = createSmtpServer();
             Step(
                 function() {
                     smtp.listen(1623, this);
                 },
                 function(err) {
                     if (err) throw err;
-                    setupAppConfig({hostname: "localhost",
-                                    port: 4815,
-                                    requireEmail: true,
-                                    smtpserver: "localhost",
-                                    smtpport: 1623
-                                   },
-                                   this);
+                    setupAppConfig({
+                        hostname: "localhost",
+                        port: 4815,
+                        requireEmail: true,
+                        smtpserver: "localhost",
+                        smtpport: 1623,
+                        smtppass: "smtppass",
+                        smtpuser: "smtpuser"
+                    }, this);
                 },
                 function(err, app) {
                     if (err) {
@@ -83,7 +85,7 @@ suite.addBatch({
                 app.close();
             }
             if (smtp) {
-                smtp.end(function(err) {});
+                smtp.close();
             }
         },
         "it works": function(err, app, smtp) {
@@ -117,7 +119,7 @@ suite.addBatch({
                     var callback = this.callback;
                     Step(
                         function() {
-                            oneEmail(smtp, "jamesjr@pump.test", this.parallel());
+                            oneEmail("jamesjr@pump.test", this.parallel());
                             registerEmail(cl, "jj", "dyn|o|mite!", "jamesjr@pump.test", this.parallel());
                         },
                         callback
@@ -166,7 +168,7 @@ suite.addBatch({
 
                             Step(
                                 function() {
-                                    oneEmail(smtp, "jamessr@pump.test", this.parallel());
+                                    oneEmail("jamessr@pump.test", this.parallel());
                                     registerEmail(cl, "james", "work|hard", "jamessr@pump.test", this.parallel());
                                 },
                                 function(err, message, results) {
@@ -255,7 +257,7 @@ suite.addBatch({
 
                             Step(
                                 function() {
-                                    oneEmail(smtp, "thelma@pump.test", this.parallel());
+                                    oneEmail("thelma@pump.test", this.parallel());
                                     registerEmail(cl, "thelma", "dance4fun", "thelma@pump.test", this.parallel());
                                 },
                                 function(err, message, results) {
@@ -332,7 +334,7 @@ suite.addBatch({
                     var callback = this.callback;
                     Step(
                         function() {
-                            oneEmail(smtp, "bookman@pump.test", this.parallel());
+                            oneEmail("bookman@pump.test", this.parallel());
                             registerEmail(cl, "bookman", "i*am*super.", "bookman@pump.test", this.parallel());
                         },
                         callback

--- a/util/docker-candidacy.sh
+++ b/util/docker-candidacy.sh
@@ -6,15 +6,11 @@ cd $(dirname $0)
 
 TYPE=$(./determine-release-type.sh)
 
-check_right_node_version() {
-	test $(node -p "require('process').versions.node.split('.')[0]") = 8
-}
-
 if [ $TRAVIS_EVENT_TYPE = cron ]; then
-	check_right_node_version && exit 0
+	exit 0
 # Don't wait for the cronjob if it's a non-alpha
 elif [ $TYPE = release -o $TYPE = beta ]; then
-	check_right_node_version && exit 0
+	exit 0
 fi
 
 exit 1


### PR DESCRIPTION
Acording with our [policy ](https://github.com/pump-io/pump.io/wiki/Node.js-version-support) we should add support for the current/LTS node version and drop the EOL version 

Also closes #1118