### PR TITLE
Destroy host credentials if are invalid

### DIFF
--- a/lib/model/host.js
+++ b/lib/model/host.js
@@ -124,6 +124,25 @@ Host.ensureHost = function(hostname, callback) {
     );
 };
 
+Host.prototype.destroyHost = function(callback) {
+
+    var host = this;
+
+    Step(
+        function() {
+            Credentials.getForHost(URLMaker.hostname, host, this);
+        },
+        function(err, cred) {
+            if (err) throw err;
+            cred.del(this);
+        },
+        function(err) {
+            host.del(this);
+        },
+        callback
+    );
+};
+
 Host.discover = function(hostname, callback) {
 
     var props = {

--- a/routes/web.js
+++ b/routes/web.js
@@ -250,10 +250,16 @@ var handleRemote = function(req, res, next) {
             host.getRequestToken(this);
         },
         function(err, rt) {
-            if (err) {
-                next(err);
-            } else {
+            if (!err) {
                 res.redirect(host.authorizeURL(rt));
+            } else if (err.statusCode) {
+                if (host && err.statusCode === 400) {
+                    req.log.warn("Invalid or old host credentials", err);
+                    host.destroyHost(req.log.error);
+                }
+                next(new HTTPError(err.data, err.statusCode));
+            } else {
+                next(err);
             }
         }
     );


### PR DESCRIPTION
If a user reinstall your instance but keeping the same domain/host and
when try to login with a remote instance previously logined will get a
error and will be impossible to use again the same domain/instance.