### PR TITLE
Drop Node 13 and test on Node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "10"
-  - "12"
-  - "13"
+  - 10
+  - 12
+  - 14
 dist: trusty
 env:
   - CXX=g++-4.8


### PR DESCRIPTION
Tagging as semver-major because I don't want us to ship a release that appears to support Node 13.