### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/bin/pump-import-collection
+++ b/bin/pump-import-collection
@@ -960,7 +960,7 @@ var isUser = function(object) {
 
 var betterID = function(activity) {
     var dt = new Date(activity.published),
-        tagDate = dt.toISOString().substr(0, 10);
+        tagDate = dt.toISOString().slice(0, 10);
 
     return "tag:"+URLMaker.hostname+","+tagDate+":"+activity.verb+":"+activity.object.id;
 };

--- a/lib/activityspam.js
+++ b/lib/activityspam.js
@@ -79,7 +79,7 @@ var ActivitySpam = {
                 }
                 if (!resp.headers ||
                     !resp.headers["content-type"] ||
-                    resp.headers["content-type"].substr(0, "application/json".length) !== "application/json") {
+                    resp.headers["content-type"].slice(0, "application/json".length) !== "application/json") {
                     throw new Error("Incorrect response type");
                 }
                 // Throws an exception

--- a/lib/app.js
+++ b/lib/app.js
@@ -690,7 +690,7 @@ var makeApp = function(configBase, callback) {
         app.use(function(err, req, res, next) {
             log.error({err: err, req: req}, err.message);
             if (err instanceof HTTPError) {
-                if (req.xhr || req.originalUrl.substr(0, 5) === "/api/") {
+                if (req.xhr || req.originalUrl.slice(0, 5) === "/api/") {
                     res.status(err.code).json({error: err.message});
                 } else if (req.accepts("html")) {
                     res.status(err.code);

--- a/lib/dialback.js
+++ b/lib/dialback.js
@@ -204,7 +204,7 @@ var dialback = function(req, res, next) {
             res.send(msg);
         },
         parseFields = function(str) {
-            var fstr = str.substr(9); // everything after "Dialback "
+            var fstr = str.slice(9); // everything after "Dialback "
             var pairs = fstr.split(/,\s+/); // XXX: won't handle blanks inside values well
             var fields = {};
             pairs.forEach(function(pair) {
@@ -223,7 +223,7 @@ var dialback = function(req, res, next) {
 
     auth = req.headers.authorization;
 
-    if (auth.substr(0, 9) !== "Dialback ") {
+    if (auth.slice(0, 9) !== "Dialback ") {
         unauthorized("Authorization scheme is not 'Dialback'");
         return;
     }

--- a/lib/model/activity.js
+++ b/lib/model/activity.js
@@ -1170,7 +1170,7 @@ Activity.makeContent = function(props) {
 
             switch (last) {
             case "y":
-                return verb.substr(0, verb.length - 1) + "ied";
+                return verb.slice(0, -1) + "ied";
             case "e":
                 return verb + "d";
             default:

--- a/lib/model/activityobject.js
+++ b/lib/model/activityobject.js
@@ -977,7 +977,7 @@ ActivityObject.prototype.efface = function(callback) {
 };
 
 ActivityObject.canonicalID = function(id) {
-    if (id.indexOf("@") !== -1 && id.substr(0, 5) !== "acct:") {
+    if (id.indexOf("@") !== -1 && id.slice(0, 5) !== "acct:") {
         return "acct:" + id;
     }
     return id;
@@ -1344,7 +1344,7 @@ ActivityObject.protocolOf = function(id) {
         return null;
     }
 
-    return (id.substr(0, id.indexOf(":")));
+    return (id.slice(0, id.indexOf(":")));
 };
 
 ActivityObject.mergeLinks = function(jrd, obj) {
@@ -1403,7 +1403,7 @@ ActivityObject.getRemoteObject = function(url, retries, callback) {
                     throw err;
                 }
             } else {
-                if (!resp.headers["content-type"] || resp.headers["content-type"].substr(0, 16) !== "application/json") {
+                if (!resp.headers["content-type"] || resp.headers["content-type"].slice(0, 16) !== "application/json") {
                     throw new Error("Bad content type: " + resp.headers["content-type"]);
                 }
                 parsed = JSON.parse(body);

--- a/lib/model/credentials.js
+++ b/lib/model/credentials.js
@@ -141,8 +141,8 @@ Credentials.register = function(id, hostname, endpoint, callback) {
 
             var toSend, body;
 
-            if (id.substr(0, 5) === "acct:") {
-                toSend = id.substr(5);
+            if (id.slice(0, 5) === "acct:") {
+                toSend = id.slice(5);
             } else {
                 toSend = id;
             }
@@ -167,7 +167,7 @@ Credentials.register = function(id, hostname, endpoint, callback) {
                 throw new Error("No content type");
             }
 
-            if (resp.headers["content-type"].substr(0, "application/json".length) !== "application/json") {
+            if (resp.headers["content-type"].slice(0, "application/json".length) !== "application/json") {
                 throw new Error("Bad content type: " + resp.headers["content-type"]);
             }
 

--- a/lib/model/person.js
+++ b/lib/model/person.js
@@ -217,8 +217,8 @@ Person.prototype.getInbox = function(callback) {
             if (err) throw err;
             if (user) {
                 callback(null, URLMaker.makeURL("api/user/" + user.nickname + "/inbox"));
-            } else if (person.id.substr(0, 5) === "acct:") {
-                wf.webfinger(person.id.substr(5), this);
+            } else if (person.id.slice(0, 5) === "acct:") {
+                wf.webfinger(person.id.slice(5), this);
             } else {
                 // XXX: try LRDD for http: and https: URIs
                 // XXX: try LRDD for http: and https: URIs

--- a/lib/upgrader.js
+++ b/lib/upgrader.js
@@ -63,7 +63,7 @@ var Upgrader = new (function() {
             var img,
                 urlToSlug = function(person, url) {
                     var start = url.indexOf("/" + person.preferredUsername + "/");
-                    return url.substr(start + 1);
+                    return url.slice(start + 1);
                 },
                 slug,
                 reupgrade = function(slug, callback) {

--- a/lib/urlmaker.js
+++ b/lib/urlmaker.js
@@ -52,7 +52,7 @@ var URLMaker = {
             path = "/" + path;
         }
         if (path[path.length-1] === "/") {
-            path = path.substr(0, path.length-1);
+            path = path.slice(0, -1);
         }
         return path;
     },

--- a/lib/uuidv5.js
+++ b/lib/uuidv5.js
@@ -35,7 +35,7 @@ var _ = require("lodash"),
 var _byteToHex = [];
 var _hexToByte = {};
 for (var i = 0; i < 256; i++) {
-    _byteToHex[i] = (i + 0x100).toString(16).substr(1);
+    _byteToHex[i] = (i + 0x100).toString(16).slice(1);
     _hexToByte[_byteToHex[i]] = i;
 }
 

--- a/public/javascript/pump.js
+++ b/public/javascript/pump.js
@@ -259,10 +259,10 @@ if (!window.Pump) {
         var here = window.location;
 
         if (url.indexOf(":") == -1) {
-            if (url.substr(0, 1) == "/") {
+            if (url.slice(0, 1) == "/") {
                 url = here.protocol + "//" + here.host + url;
             } else {
-                url = here.href.substr(0, here.href.lastIndexOf("/") + 1) + url;
+                url = here.href.slice(0, here.href.lastIndexOf("/") + 1) + url;
             }
         }
 
@@ -391,7 +391,7 @@ if (!window.Pump) {
             str = window.location.search;
         }
 
-        pairs = str.substr(1).split("&");
+        pairs = str.slice(1).split("&");
 
         _.each(pairs, function(pairStr) {
             var pair = pairStr.split("=", 2),

--- a/public/javascript/pump/view.js
+++ b/public/javascript/pump/view.js
@@ -2646,8 +2646,8 @@
                 }),
                 strToObj = function(str) {
                     var colon = str.indexOf(":"),
-                        type = str.substr(0, colon),
-                        id = str.substr(colon+1);
+                        type = str.slice(0, colon !== -1 ? colon : 0),
+                        id = str.slice(colon+1);
                     return new Pump.ActivityObject({
                         id: id,
                         objectType: type
@@ -2736,8 +2736,8 @@
                         cc = view.$("#post-picture #picture-cc").val(),
                         strToObj = function(str) {
                             var colon = str.indexOf(":"),
-                                type = str.substr(0, colon),
-                                id = str.substr(colon+1);
+                                type = str.slice(0, colon !== -1 ? colon : 0),
+                                id = str.slice(colon+1);
                             return Pump.ActivityObject.unique({
                                 id: id,
                                 objectType: type
@@ -3165,8 +3165,8 @@
                 var val = element.val(),
                     strToObj = function(str) {
                         var colon = str.indexOf(":"),
-                            type = str.substr(0, colon),
-                            id = str.substr(colon+1);
+                            type = str.slice(0, colon !== -1 ? colon : 0),
+                            id = str.slice(colon+1);
                         return new Pump.ActivityObject({
                             id: id,
                             objectType: type

--- a/public/template/choose-contact.pug
+++ b/public/template/choose-contact.pug
@@ -8,8 +8,8 @@
       ul.thumbnails
         each person in people.items
           -
-            var abbrev = (person.id && person.id.substr(0, 5) === 'acct:') ?
-            person.id.substr(5) : person.preferredUsername,
+            var abbrev = (person.id && person.id.slice(0, 5) === 'acct:') ?
+            person.id.slice(5) : person.preferredUsername,
             imgUrl = (person.image && person.image.url) ? person.image.url : "/images/default.png";
           li.thumbnail.span1(data-person-id=person.id, data-title=abbrev)
           img.img-rounded(src=imgUrl, width="64", height="64", alt=abbrev)

--- a/public/template/lib/welcome.pug
+++ b/public/template/lib/welcome.pug
@@ -9,7 +9,7 @@ ul
 
   li
     | Your account id is 
-    strong= (profile.id && profile.id.substr(0, 5) === 'acct:') ? profile.id.substr(5) : profile.id
+    strong= (profile.id && profile.id.slice(0, 5) === 'acct:') ? profile.id.slice(5) : profile.id
     | . You can use it with 
     a(href="https://pumpio.readthedocs.org/en/latest/clients.html") pump.io-enabled applications
     | .

--- a/public/template/major-person.pug
+++ b/public/template/major-person.pug
@@ -10,8 +10,8 @@ li.media.person.major(data-person-id=person.id)
       a(href=person.url)!= person.displayName
       |  
       small
-        if person.id && person.id.substr(0, 5) === 'acct:'
-          = person.id.substr(5)
+        if person.id && person.id.slice(0, 5) === 'acct:'
+          = person.id.slice(5)
         else
           = person.preferredUsername
 

--- a/public/template/member.pug
+++ b/public/template/member.pug
@@ -11,8 +11,8 @@ li.media.person.major.member(data-person-id=person.id)
     h4.media-heading
       a(href=person.url)!= person.displayName
       small
-        if person.id && person.id.substr(0, 5) === 'acct:'
-          = person.id.substr(5)
+        if person.id && person.id.slice(0, 5) === 'acct:'
+          = person.id.slice(5)
         else
           = person.preferredUsername
 

--- a/public/template/object-client.pug
+++ b/public/template/object-client.pug
@@ -33,7 +33,7 @@ mixin authorship(object)
             br
 
           if irt.content
-            != irt.content.length <= 80 ? irt.content : irt.content.substr(0, 80) + "…"
+            != irt.content.length <= 80 ? irt.content : irt.content.slice(0, 80) + "…"
           else if irt.objectType === "image"
             span.inreplyto-image (Image)
 

--- a/public/template/profile-block.pug
+++ b/public/template/profile-block.pug
@@ -12,8 +12,8 @@
       span.p-name!= profile.displayName
       |  
       small.p-nickname
-        if profile.id && profile.id.substr(0, 5) === 'acct:'
-          = profile.id.substr(5)
+        if profile.id && profile.id.slice(0, 5) === 'acct:'
+          = profile.id.slice(5)
         else
           = profile.preferredUsername
 

--- a/test/lib/http.js
+++ b/test/lib/http.js
@@ -422,7 +422,7 @@ var proxy = function(options, callback) {
 
     app.all(front.path + "/*", function(req, res, next) {
         var full = req.originalUrl,
-            rel = full.substr(front.path.length + 1),
+            rel = full.slice(front.path.length + 1),
             options = {
                 hostname: back.hostname,
                 port: back.port,

--- a/test/oauth2-authorization-e2e-test.js
+++ b/test/oauth2-authorization-e2e-test.js
@@ -189,7 +189,7 @@ vows.describe("OAuth 2.0 authorization flow")
                                     br.assert.success();
                                     br.assert.redirected();
                                     var bu = br.url;
-                                    var bu1 = bu.substr(0, REDIRECT_URI.length);
+                                    var bu1 = bu.slice(0, REDIRECT_URI.length);
                                     assert.equal(bu1, REDIRECT_URI);
                                     var bup = urlparse(bu, true);
                                     assert.isObject(bup.query);

--- a/test/pump-through-proxy-e2e-test.js
+++ b/test/pump-through-proxy-e2e-test.js
@@ -127,7 +127,7 @@ suite.addBatch({
                 assert.equal(res.statusCode, 200);
                 assert.isObject(res.headers);
                 assert.include(res.headers, "content-type");
-                assert.equal("text/html", res.headers["content-type"].substr(0, "text/html".length));
+                assert.equal("text/html", res.headers["content-type"].slice(0, "text/html".length));
             }
         },
         "and we register a client": {
@@ -193,7 +193,7 @@ suite.addBatch({
                 assert.equal(res.statusCode, 200);
                 assert.isObject(res.headers);
                 assert.include(res.headers, "content-type");
-                assert.equal("text/html", res.headers["content-type"].substr(0, "text/html".length));
+                assert.equal("text/html", res.headers["content-type"].slice(0, "text/html".length));
             }
         },
         "and we register a client directly": {

--- a/test/scrubber-activity-api-e2e-test.js
+++ b/test/scrubber-activity-api-e2e-test.js
@@ -59,7 +59,7 @@ var deepProperty = function(object, property) {
     } else if (i === -1) { // no dots
         return object[property];
     } else {
-        return deepProperty(object[property.substr(0, i)], property.substr(i + 1));
+        return deepProperty(object[property.slice(0, i)], property.slice(i + 1));
     }
 };
 

--- a/test/scrubber-favorite-api-e2e-test.js
+++ b/test/scrubber-favorite-api-e2e-test.js
@@ -46,7 +46,7 @@ var deepProperty = function(object, property) {
     } else if (i === -1) { // no dots
         return object[property];
     } else {
-        return deepProperty(object[property.substr(0, i)], property.substr(i + 1));
+        return deepProperty(object[property.slice(0, i)], property.slice(i + 1));
     }
 };
 

--- a/test/scrubber-follow-api-e2e-test.js
+++ b/test/scrubber-follow-api-e2e-test.js
@@ -46,7 +46,7 @@ var deepProperty = function(object, property) {
     } else if (i === -1) { // no dots
         return object[property];
     } else {
-        return deepProperty(object[property.substr(0, i)], property.substr(i + 1));
+        return deepProperty(object[property.slice(0, i)], property.slice(i + 1));
     }
 };
 

--- a/test/scrubber-object-api-e2e-test.js
+++ b/test/scrubber-object-api-e2e-test.js
@@ -46,7 +46,7 @@ var deepProperty = function(object, property) {
     } else if (i === -1) { // no dots
         return object[property];
     } else {
-        return deepProperty(object[property.substr(0, i)], property.substr(i + 1));
+        return deepProperty(object[property.slice(0, i)], property.slice(i + 1));
     }
 };
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.